### PR TITLE
Fix typo in BrowserUtils highlight comment

### DIFF
--- a/src/test/java/com/vytrack/utilities/BrowserUtils.java
+++ b/src/test/java/com/vytrack/utilities/BrowserUtils.java
@@ -381,7 +381,7 @@ public class BrowserUtils {
     }
 
     /**
-     * Highlighs an element by changing its background and border color
+     * Highlights an element by changing its background and border color
      *
      * @param element
      */


### PR DESCRIPTION
## Summary
- fix typo in BrowserUtils highlight comment

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a5589802d4832999661e453a08f2c4